### PR TITLE
claim an idea: attestation data duplicator

### DIFF
--- a/contributions/attestation-data-duplicator.md
+++ b/contributions/attestation-data-duplicator.md
@@ -3,16 +3,16 @@ title: "Attestation Data Duplicator"
 description: "One of the primary challenges currently facing the AttestationStation is the need to bootstrap the system with high-quality attestations. Luckily, blockchains already have an enormous amount of useful data that can be converted into attestations."
 lang: "en-US"
 type: "Project Idea"
-authors: ["@smartcontracts (GitHub) @ OP Labs"]
+authors: ["@aagbotemi (GitHub) @ Duplikaat Team","@goodness5 (GitHub) @ Duplikaat Team","@okolievans (GitHub) @ Duplikaat Team","@olorunfemibabs (GitHub) @ Duplikaat Team", "@dadsec-dev (GitHub) @ Duplikaat Team"]
 category: "dev-tooling"
 effort: "Large"
 skill-sets: ["Front End Development", "Back End Development", "Full Stack Development", "Smart Contract Development"]
 labels: ["Attestations","Developer Tooling","Accessibility/Transparency","Governance"]
 contributions:
-  contributors: [""]
-  discussion-link: ""
+  contributors: ["@aagbotemi (GitHub) @ Duplikaat Team","@goodness5 (GitHub) @ Duplikaat Team","@okolievans (GitHub) @ Duplikaat Team","@olorunfemibabs (GitHub) @ Duplikaat Team", "@dadsec-dev (GitHub) @ Duplikaat Team"]
+  discussion-link: "https://github.com/ethereum-optimism/ecosystem-contributions/discussions/175"
   links: [""]
-  execution-status: "not-started"
+  execution-status: "in-discussion"
 ---
 
 # Attestation Data Duplicator

--- a/contributions/attestation-data-duplicator.md
+++ b/contributions/attestation-data-duplicator.md
@@ -3,7 +3,7 @@ title: "Attestation Data Duplicator"
 description: "One of the primary challenges currently facing the AttestationStation is the need to bootstrap the system with high-quality attestations. Luckily, blockchains already have an enormous amount of useful data that can be converted into attestations."
 lang: "en-US"
 type: "Project Idea"
-authors: ["@aagbotemi (GitHub) @ Duplikaat Team","@goodness5 (GitHub) @ Duplikaat Team","@okolievans (GitHub) @ Duplikaat Team","@olorunfemibabs (GitHub) @ Duplikaat Team", "@dadsec-dev (GitHub) @ Duplikaat Team"]
+authors: ["@smartcontracts (GitHub) @ OP Labs"]
 category: "dev-tooling"
 effort: "Large"
 skill-sets: ["Front End Development", "Back End Development", "Full Stack Development", "Smart Contract Development"]


### PR DESCRIPTION
Hey from the Duplikaat Team,

we are working at the solution for the Attestation-Based Data Duplicator idea as described at https://contribute.optimism.io/issue/attestation-data-duplicator

We already implemented some projects on Ethereum, Starknet and Polygon and now we want to create a developer tool on Optimism.

We want to implement these points:

Addresses that were part of the initial ETH genesis allocation
Addresses that have held some NFT for more than X amount of time
Addresses that have donated to GitCoin rounds
Addresses that have received POAPs from important events

Everyone is welcome to help to discuss this new idea with us!