### PR TITLE
OP Mainnet Resource Usage Tracker Proposal

### DIFF
--- a/contributions/op-mainnet-resource-usage-tracker.md
+++ b/contributions/op-mainnet-resource-usage-tracker.md
@@ -9,10 +9,10 @@ effort: "Large"
 skill-sets: ["Front End Development", "Data Analysis", "Full Stack Development"]
 labels: ["Accessibility/Transparency", "Developer Tooling", "OP Stack"]
 contributions: 
-        contributors: [""]
-        discussion-link: ""
+        contributors: ["@sanprab (GitHub) @ CoinTracker"]
+        discussion-link: "https://github.com/ethereum-optimism/ecosystem-contributions/discussions/195"
         links: [""]
-        execution-status: "not-started"
+        execution-status: "in-progress-open"
 ---
 
 # OP Mainnet Resource Usage Tracker


### PR DESCRIPTION
# Claiming an Idea

To claim an idea you will need to jump to [this GitHub](https://github.com/ethereum-optimism/ecosystem-contributions/tree/main/contributions) first, then complete the following tasks:

* [x] Create a PR. Copy paste this todo list into the description.
* [x] Create a discussion thread:
    * Inside this repo in [Discussions](https://github.com/ethereum-optimism/ecosystem-contributions/discussions/categories/builds)
    * In the [Optimism Discord](https://discord.gg/optimism) > Builder District > [Builder Ideas](https://discord.gg/vejYbHWU). 
        * Note you will need to get the developer role in Discord to see the Builder District. 
* [x] Fill in the contributor info:

        ``` md
        contributors: ["@sanprab (GitHub) @ CoinTracker"]
        discussion-link: "https://github.com/ethereum-optimism/ecosystem-contributions/discussions/195"
        links: []
        execution-status: "in-progress-open"
        ```

  - [x] Add the team working on it. The format is `"@handle (Platform) @ team"`.
        For example: `["@tezter (GitHub) @ DeFo", "@jack (Twitter)"]`
    * [x] Add the link to your discussion in GitHub/Discord. You can _**ONLY HAVE ONE LINK for your discussion.**_
    * [ ] (OPTIONAL) Add links to your repository, the website for the build, or other relevant links for your build. 
    * [x] Add your execution status:
        * `"not-started"`: This idea does not currently have anyone working on it. Why don't you pick it up?
        * `"in-discussion"`: This idea is being discussed. See the links section for where the discussion is taking place!
        * `"in-progress-open"`: This idea is being built, and the contributors are open to help! Jump into the discussion in links to get started!
        * `"in-progress-closed"`: This idea is being built, but the contributors are in a closed team. You can still work on the idea by yourself or with friends!
        * `"completed"`: The idea has been built! Check out the links for more info
        * `"abandoned"`: The contributors working on this moved onto something else. Why don't you pick up where they left off?
