### PR TITLE
fix: should fix the geolocation ip

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const GET = async (req: NextRequest) => {
     try {
         //extract the ip
-        const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip;
+        const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip || "").split(",")[0].trim();
         if(!ip) {
             return NextResponse.json(
                 { error: "Unable to determine IP address: " + ip },


### PR DESCRIPTION
from production the ip that send to mix panel is "1.46.X.X, 162.XXX.X.X"
but we want only "1.46.X.X" to track the geolocation, so select only first one should fix the problem.