### PR TITLE
Hotfix Geolocation On Production

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 export const GET = async (req: NextRequest) => {
     try {
         //extract the ip
-        const ip = req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip;
+        const ip = (req.headers.get("x-forwarded-for") || req.headers.get("x-real-ip") || req.ip || "").split(",")[0].trim();
         if(!ip) {
             return NextResponse.json(
                 { error: "Unable to determine IP address: " + ip },


### PR DESCRIPTION
The IP sent to the mix panel in production is "1.46.X.X, 162.XXX.X.X"
but we want only "1.46.X.X" to track the geolocation, so selecting only the first one should fix the problem.

![telegram-cloud-photo-size-2-5321209092854900347-w](https://github.com/user-attachments/assets/1caee74a-417c-4eb9-96b7-c1b51f9fe876)
