### PR TITLE
Fix possessive apostrophe in delegate-health.md

### DIFF
--- a/contributions/delegate-health.md
+++ b/contributions/delegate-health.md
@@ -1,6 +1,6 @@
 ---
 title: 'Alternative Visualization of Delegate Health'
-description: "Create a visualization of a delegates health and overall participation in the Collective! Utilize information such as the delegate wallet address, what contracts their wallet has interacted with, their voting history, who has delegated to them, and more! The goal is for anyone to be able to visualize top delegate's health and level of participation within the Collective!"
+description: "Create a visualization of a delegates health and overall participation in the Collective! Utilize information such as the delegate wallet address, what contracts their wallet has interacted with, their voting history, who has delegated to them, and more! The goal is for anyone to be able to visualize top delegates' health and level of participation within the Collective!"
 lang: 'en-US'
 type: 'Project Idea'
 authors: ['opmxwell']


### PR DESCRIPTION
## Summary
- Fixed possessive apostrophe: "top delegate's health" -> "top delegates' health"
- The context refers to multiple delegates, so the plural possessive is correct

## Test plan
- [x] Verified the grammar is correct