### PR TITLE
Fix contributors array format in decentralized-pgp-key-server.md

### DIFF
--- a/contributions/decentralized-pgp-key-server.md
+++ b/contributions/decentralized-pgp-key-server.md
@@ -9,7 +9,7 @@ effort: "Medium"
 skill-sets: ["Protocol Development", "Back End Development", "Smart Contract Development"]
 labels: ["Attestations", "Developer Tooling", "Accessibility/Transparency"]
 contributions:
-  contributors: ["@lucas-op (GitHub), @harshmittal1750 (GitHub). @ribeirojose (GitHub) "]
+  contributors: ["@lucas-op (GitHub)", "@harshmittal1750 (GitHub)", "@ribeirojose (GitHub)"]
   discussion-link: "https://github.com/ethereum-optimism/ecosystem-contributions/discussions/197"
   links: ["https://github.com/bleu/eas-pgp"]
   execution-status: "in-progress-open"


### PR DESCRIPTION
## Summary
- Fixed contributors array format to properly separate each contributor as an individual array element
- Changed from a single string with comma and period separators to proper YAML array format
- Removed trailing whitespace

## Test plan
- [x] Verified the YAML array format matches other contribution files